### PR TITLE
Cleanup setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,12 +6,18 @@
 # USAGE
 # -----
 #
-# $> ./tyk_quickstart.sh {IP ADDRESS OF DOCKER VM}
+# $> ./start.sh {IP ADDRESS OF DOCKER VM}
 
 # OSX users will need to specify a virtual IP, linux users can use 127.0.0.1
 
+# Tyk dashboard settings
+TYK_DASHBOARD_USERNAME=$(env LC_CTYPE=C tr -dc "a-z0-9" < /dev/urandom | head -c 10)"@test.com"
+TYK_DASHBOARD_PASSWORD="test123"
+
+# Tyk portal settings
+TYK_PORTAL_DOMAIN="www.tyk-portal-test.com"
+
 DOCKER_IP=127.0.0.1
-DOMAIN=www.tyk.docker
 
 if [ -n "$DOCKER_HOST" ]
 then
@@ -29,9 +35,9 @@ fi
 
 if [ -n "$2" ]
 then
-		DOMAIN=$2
+		TYK_PORTAL_DOMAIN=$2
 		echo "Docker portal domain address explicitly set."
-		echo "Using $DOMAIN as Tyk host address."
+		echo "Using $TYK_PORTAL_DOMAIN as Tyk host address."
 fi
 
 if [ -z "$1" ]
@@ -40,40 +46,31 @@ then
         echo "If this is wrong, please specify the instance IP address (e.g. ./setup.sh 192.168.1.1)"
 fi
 
-LOCALIP=$DOCKER_IP
-RANDOM_USER=$(env LC_CTYPE=C tr -dc "a-z0-9" < /dev/urandom | head -c 10)
-PASS="test123"
-
 echo "Creating Organisation"
-ORGDATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"owner_name": "TestOrg5 Ltd.","owner_slug": "testorg", "cname_enabled":true}' http://$LOCALIP:3000/admin/organisations 2>&1)
-#echo $ORGDATA
-ORGID=$(echo $ORGDATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Meta"]')
-echo "ORGID: $ORGID" 
+ORG_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"owner_name": "TestOrg5 Ltd.","owner_slug": "testorg", "cname_enabled":true}' http://$DOCKER_IP:3000/admin/organisations 2>&1)
+ORG_ID=$(echo $ORG_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Meta"]')
+echo "ORG ID: $ORG_ID"
 
 echo "Adding new user"
-USER_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$RANDOM_USER'@test.com","active": true,"org_id": "'$ORGID'"}' http://$LOCALIP:3000/admin/users 2>&1)
-#echo $USER_DATA
-USER_CODE=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
-echo "USER AUTH: $USER_CODE" 
-
-USER_LIST=$(curl --silent --header "authorization: $USER_CODE" http://$LOCALIP:3000/api/users 2>&1)
-#echo $USER_LIST
-
+USER_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$TYK_DASHBOARD_USERNAME'","active": true,"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/admin/users 2>&1)
+USER_AUTH=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
+USER_LIST=$(curl --silent --header "authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/users 2>&1)
 USER_ID=$(echo $USER_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["users"][0]["id"]')
-echo "NEW ID: $USER_ID"
+echo "USER AUTH: $USER_AUTH"
+echo "USER ID: $USER_ID"
 
 echo "Setting password"
-OK=$(curl --silent --header "authorization: $USER_CODE" --header "Content-Type:application/json" http://$LOCALIP:3000/api/users/$USER_ID/actions/reset --data '{"new_password":"'$PASS'"}')
-
+OK=$(curl --silent --header "authorization: $USER_AUTH" --header "Content-Type:application/json" http://$DOCKER_IP:3000/api/users/$USER_ID/actions/reset --data '{"new_password":"'$TYK_DASHBOARD_PASSWORD'"}')
 
 echo "Setting up the portal domain"
-curl -d "domain="$DOMAIN"" -H "admin-auth:12345" http://tyk_dashboard.tyk_dashboard.docker:3000/admin/organisations/$ORGID/generate-portals
+OK=$(curl --silent -d "domain="$TYK_PORTAL_DOMAIN"" -H "admin-auth:12345" http://$DOCKER_IP:3000/admin/organisations/$ORG_ID/generate-portals)
 
 echo ""
 
 echo "DONE"
 echo "===="
-echo "Login at http://$LOCALIP:3000/"
-echo "User: $RANDOM_USER@test.com"
-echo "Pass: $PASS"
+echo "Login at http://$DOCKER_IP:3000/"
+echo "Username: $TYK_DASHBOARD_USERNAME"
+echo "Password: $TYK_DASHBOARD_PASSWORD"
+echo "Portal: http://$TYK_PORTAL_DOMAIN"
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 # USAGE
 # -----
 #
-# $> ./start.sh {IP ADDRESS OF DOCKER VM}
+# $> ./setup.sh {IP ADDRESS OF DOCKER VM}
 
 # OSX users will need to specify a virtual IP, linux users can use 127.0.0.1
 

--- a/tyk_analytics.conf
+++ b/tyk_analytics.conf
@@ -23,7 +23,7 @@
     "show_org_id": true,
     "enable_duplicate_slugs": true,
     "host_config" : {
-        "override_hostname": "tyk.docker",
+        "override_hostname": "www.tyk-portal-test.com",
         "disable_org_slug_prefix": true,
         "enable_host_names": false,
         "hostname": "",


### PR DESCRIPTION
* Fix setting the portal domain, this was using a hardcoded address `tyk_dashboard.tyk_dashboard.docker`
* Use www.tyk-portal-test.com to match the v1.9 documentation
* Move some of the vars to the top and rename to be clearer